### PR TITLE
Bug[error 500] fix: don't treat 'building' field as always present

### DIFF
--- a/main.py
+++ b/main.py
@@ -85,7 +85,11 @@ class Class:
         for (field_fn, field_name) in CLASS_DESC_FIELDS:
             self.desc += f'{field_name}: {field_fn(json)}\n'
         self.auditorium = json['auditorium']
-        self.location = f'{self.auditorium}, {json["building"]}'
+        
+        self.location = f'{self.auditorium}'
+        if 'building' in json:
+            self.location += f', {json["building"]}'
+        
         if SHORT == '0':
             self.desc += f'Аудитория: {self.auditorium}'
 


### PR DESCRIPTION
For last 5 days, API returned error 500. The reason was the field "bulding" stop being present for some lesson entries (e.g. online exams).